### PR TITLE
support spaces in URLs with newer CURL versions

### DIFF
--- a/src/retriever.cpp
+++ b/src/retriever.cpp
@@ -34,6 +34,8 @@
 
 #include <curl/curl.h>
 
+#include <regex>
+
 namespace resource_retriever
 {
 
@@ -118,6 +120,9 @@ MemoryResource Retriever::get(const std::string& url)
 
     mod_url = "file://" + package_path + mod_url;
   }
+  
+  //newer versions of curl do not accept spaces in URLs
+  mod_url = std::regex_replace(mod_url, std::regex(" "), "%20");
 
   curl_easy_setopt(curl_handle_, CURLOPT_URL, mod_url.c_str());
   curl_easy_setopt(curl_handle_, CURLOPT_WRITEFUNCTION, curlWriteFunc);


### PR DESCRIPTION
see https://stackoverflow.com/questions/69254520/how-to-use-curlu-allow-space-with-curl-easy-perform
and https://github.com/ros/resource_retriever/issues/84